### PR TITLE
Specifications of the SMF behavior

### DIFF
--- a/terminology/server-module-function.md
+++ b/terminology/server-module-function.md
@@ -13,7 +13,7 @@ string | number | boolean
 A SMF should be a `read-only` operation on the system (not changing any files), and
 
 1. Return a JSON-serializable value on success
-2. Throw an `Error` with a descriptive error message (`throw new Error('what went wrong')`)
+2. Throw (or, for asynchronous modules, reject with) an `Error` with a descriptive error message (`throw new Error('what went wrong')`)
 3. **Not** log to the console or do other "active" operations. Handling error messages etc. is up to the SM's consumer (in most cases, [server-base](https://github.com/server-state/server-base)).
 
 The above guidelines shall not be seen as strict rules, but exceptions should be well-justified (especially for official modules) to allow for consistency and ease of use.

--- a/terminology/server-module-function.md
+++ b/terminology/server-module-function.md
@@ -9,3 +9,11 @@ following signature:
 (options?: *) => Promise<object | array | string | number | boolean> | object | array |
 string | number | boolean
 ```
+
+A SMF should be a `read-only` operation on the system (not changing any files), and
+
+1. Return a JSON-serializable value on success
+2. Throw an `Error` with a descriptive error message (`throw new Error('what went wrong')`)
+3. **Not** log to the console or do other "active" operations. Handling error messages etc. is up to the SM's consumer (in most cases, [server-base](https://github.com/server-state/server-base)).
+
+The above guidelines shall not be seen as strict rules, but exceptions should be well-justified (especially for official modules) to allow for consistency and ease of use.


### PR DESCRIPTION
Specification for the SMF behavior, as explained in https://github.com/server-state/linux-raid-module/pull/4#discussion_r323403697, https://github.com/server-state/linux-raid-module/pull/4#discussion_r323047040 and https://github.com/server-state/linux-raid-module/pull/4#discussion_r323406410.